### PR TITLE
Feat/hasura config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 
 // Substitute -
 func (c *Config) Substitute() error {
+	c.Hasura.SetSourceName()
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -52,9 +52,17 @@ type Database struct {
 type Hasura struct {
 	URL                string `yaml:"url" validate:"required,url"`
 	Secret             string `yaml:"admin_secret" validate:"required"`
+	Source             string `yaml:"source" validate:"omitempty"`
 	RowsLimit          uint64 `yaml:"select_limit" validate:"gt=0"`
 	EnableAggregations bool   `yaml:"allow_aggregation"`
+	AddSource          bool   `yaml:"add_source"`
 	Rest               *bool  `yaml:"rest"`
+}
+
+func (s *Hasura) SetSourceName() {
+	if s.Source == "" {
+		s.Source = "default"
+	}
 }
 
 // Prometheus -

--- a/hasura/api.go
+++ b/hasura/api.go
@@ -124,7 +124,7 @@ func (api *API) Health(ctx context.Context) error {
 
 // AddSource -
 func (api *API) AddSource(ctx context.Context, hasura *config.Hasura, cfg config.Database) error {
-	req := request{
+	req := Request{
 		Type: "pg_add_source",
 		Args: map[string]interface{}{
 			"name": hasura.Source,
@@ -144,7 +144,7 @@ func (api *API) AddSource(ctx context.Context, hasura *config.Hasura, cfg config
 
 // ExportMetadata -
 func (api *API) ExportMetadata(ctx context.Context) (Metadata, error) {
-	req := VersionedRequest{
+	req := versionedRequest{
 		Type:    "export_metadata",
 		Version: 2,
 		Args:    map[string]interface{}{},
@@ -156,7 +156,7 @@ func (api *API) ExportMetadata(ctx context.Context) (Metadata, error) {
 
 // ReplaceMetadata -
 func (api *API) ReplaceMetadata(ctx context.Context, data *Metadata) error {
-	req := VersionedRequest{
+	req := versionedRequest{
 		Type:    "replace_metadata",
 		Version: 1,
 		Args:    data,
@@ -173,7 +173,7 @@ func (api *API) ReplaceMetadata(ctx context.Context, data *Metadata) error {
 
 // TrackTable -
 func (api *API) TrackTable(ctx context.Context, name string, source string) error {
-	req := request{
+	req := Request{
 		Type: "pg_track_table",
 		Args: map[string]string{
 			"table":  name,
@@ -190,7 +190,7 @@ func (api *API) CustomConfiguration(ctx context.Context, conf interface{}) error
 
 // CreateSelectPermissions - A select permission is used to restrict access to only the specified columns and rows.
 func (api *API) CreateSelectPermissions(ctx context.Context, table, source string, role string, perm Permission) error {
-	req := request{
+	req := Request{
 		Type: "pg_create_select_permission",
 		Args: map[string]interface{}{
 			"table":      table,
@@ -204,7 +204,7 @@ func (api *API) CreateSelectPermissions(ctx context.Context, table, source strin
 
 // DropSelectPermissions -
 func (api *API) DropSelectPermissions(ctx context.Context, table, source string, role string) error {
-	req := request{
+	req := Request{
 		Type: "pg_drop_select_permission",
 		Args: map[string]interface{}{
 			"table":  table,
@@ -217,7 +217,7 @@ func (api *API) DropSelectPermissions(ctx context.Context, table, source string,
 
 // CreateRestEndpoint -
 func (api *API) CreateRestEndpoint(ctx context.Context, name, url, queryName, collectionName string) error {
-	req := request{
+	req := Request{
 		Type: "create_rest_endpoint",
 		Args: map[string]interface{}{
 			"name":    name,

--- a/hasura/api.go
+++ b/hasura/api.go
@@ -183,6 +183,11 @@ func (api *API) TrackTable(ctx context.Context, name string, source string) erro
 	return api.post(ctx, "/v1/metadata", nil, req, nil)
 }
 
+// CustomConfiguration
+func (api *API) CustomConfiguration(ctx context.Context, conf interface{}) error {
+	return api.post(ctx, "/v1/metadata", nil, conf, nil)
+}
+
 // CreateSelectPermissions - A select permission is used to restrict access to only the specified columns and rows.
 func (api *API) CreateSelectPermissions(ctx context.Context, table, source string, role string, perm Permission) error {
 	req := request{

--- a/hasura/api.go
+++ b/hasura/api.go
@@ -130,7 +130,7 @@ func (api *API) AddSource(ctx context.Context, hasura *config.Hasura, cfg config
 			"name": hasura.Source,
 			"configuration": Configuration{
 				ConnectionInfo: ConnectionInfo{
-					DatabaseUrl:           fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", cfg.User, cfg.Password /*cfg.Host*/, "db-dipdup", cfg.Port, cfg.Database),
+					DatabaseUrl:           fmt.Sprintf("postgresql://%s:%s@%s:%d/%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database),
 					UsePreparedStatements: true,
 					IsolationLevel:        "read-committed",
 				},

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -41,7 +41,7 @@ func checkHealth(ctx context.Context, api *API) {
 }
 
 // Create - creates hasura models
-func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, views []string, custom []interface{}, models ...interface{}) error {
+func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, views []string, custom []Request, models ...interface{}) error {
 	if hasura == nil {
 		return nil
 	}

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -70,7 +70,7 @@ func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, vie
 
 	// Find our source in the existing metadata
 	var selected_source *Source = nil
-	for idx, _ := range export.Sources {
+	for idx := range export.Sources {
 		if export.Sources[idx].Name == hasura.Source {
 			selected_source = &export.Sources[idx]
 			break

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -41,7 +41,7 @@ func checkHealth(ctx context.Context, api *API) {
 }
 
 // Create - creates hasura models
-func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, views []string, models ...interface{}) error {
+func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, views []string, custom []interface{}, models ...interface{}) error {
 	if hasura == nil {
 		return nil
 	}
@@ -126,6 +126,13 @@ func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, vie
 			Filter:    map[string]interface{}{},
 		}); err != nil {
 			return err
+		}
+	}
+
+	log.Info().Msg("Running custom configurations...")
+	for _, conf := range custom {
+		if err := api.CustomConfiguration(ctx, conf); err != nil {
+			log.Warn().Err(err).Msg("")
 		}
 	}
 

--- a/hasura/hasura.go
+++ b/hasura/hasura.go
@@ -49,41 +49,58 @@ func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, vie
 
 	checkHealth(ctx, api)
 
+	if hasura.AddSource {
+		log.Info().Msg("Adding source...")
+		err := api.AddSource(ctx, hasura, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
 	metadata, err := Generate(*hasura, cfg, models...)
 	if err != nil {
 		return err
 	}
 
 	log.Info().Msg("Fetching existing metadata...")
-	export, err := api.ExportMetadata(ctx, metadata)
+	export, err := api.ExportMetadata(ctx)
 	if err != nil {
 		return err
 	}
 
-	log.Info().Msg("Merging metadata...")
-	tables := make(map[string]struct{})
-	for i := range metadata.Tables {
-		tables[metadata.Tables[i].Schema.Name] = struct{}{}
-	}
-
-	for _, table := range export.Tables {
-		if _, ok := tables[table.Schema.Name]; !ok {
-			metadata.Tables = append(metadata.Tables, table)
+	// Find our source in the existing metadata
+	var selected_source *Source = nil
+	for idx, _ := range export.Sources {
+		if export.Sources[idx].Name == hasura.Source {
+			selected_source = &export.Sources[idx]
+			break
 		}
 	}
+	if selected_source == nil {
+		return errors.Errorf("Source '%s' not found on exported metadata", hasura.Source)
+	}
 
-	if err := createQueryCollections(metadata); err != nil {
+	log.Info().Msg("Merging metadata...")
+	// Clear tables
+	// TODO: maybe instead replace tables by name.
+	selected_source.Tables = make([]Table, 0)
+	// Insert generated tables
+	for _, table := range metadata.Sources[0].Tables {
+		selected_source.Tables = append(selected_source.Tables, table)
+	}
+
+	if err := createQueryCollections(&export); err != nil {
 		return err
 	}
 
 	log.Info().Msg("Replacing metadata...")
-	if err := api.ReplaceMetadata(ctx, metadata); err != nil {
+	if err := api.ReplaceMetadata(ctx, &export); err != nil {
 		return err
 	}
 
-	if len(metadata.QueryCollections) > 0 && (hasura.Rest == nil || *hasura.Rest) {
+	if len(export.QueryCollections) > 0 && (hasura.Rest == nil || *hasura.Rest) {
 		log.Info().Msg("Creating REST endpoints...")
-		for _, query := range metadata.QueryCollections[0].Definition.Queries {
+		for _, query := range export.QueryCollections[0].Definition.Queries {
 			if err := api.CreateRestEndpoint(ctx, query.Name, query.Name, query.Name, allowedQueries); err != nil {
 				if e, ok := err.(APIError); !ok || !e.AlreadyExists() {
 					return err
@@ -94,15 +111,15 @@ func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, vie
 
 	log.Info().Msg("Tracking views...")
 	for i := range views {
-		if err := api.TrackTable(ctx, "public", views[i]); err != nil {
+		if err := api.TrackTable(ctx, views[i], hasura.Source); err != nil {
 			if !strings.Contains(err.Error(), "view/table already tracked") {
 				return err
 			}
 		}
-		if err := api.DropSelectPermissions(ctx, views[i], "user"); err != nil {
+		if err := api.DropSelectPermissions(ctx, views[i], hasura.Source, "user"); err != nil {
 			log.Warn().Err(err).Msg("")
 		}
-		if err := api.CreateSelectPermissions(ctx, views[i], "user", Permission{
+		if err := api.CreateSelectPermissions(ctx, views[i], hasura.Source, "user", Permission{
 			Limit:     hasura.RowsLimit,
 			AllowAggs: hasura.EnableAggregations,
 			Columns:   Columns{"*"},
@@ -117,17 +134,20 @@ func Create(ctx context.Context, hasura *config.Hasura, cfg config.Database, vie
 
 // Generate - creates hasura table structure in JSON from `models`. `models` should be pointer to your table models. `cfg` is DB config from YAML.
 func Generate(hasura config.Hasura, cfg config.Database, models ...interface{}) (*Metadata, error) {
-	tables := make([]Table, 0)
 	schema := getSchema(cfg)
+	source := Source{
+		Name:   hasura.Source,
+		Tables: make([]Table, 0),
+	}
 	for _, model := range models {
 		table, err := generateOne(hasura, schema, model)
 		if err != nil {
 			return nil, err
 		}
-		tables = append(tables, table.HasuraSchema)
+		source.Tables = append(source.Tables, table.HasuraSchema)
 	}
 
-	return newMetadata(2, tables), nil
+	return newMetadata(3, []Source{source}), nil
 }
 
 type table struct {

--- a/hasura/requests.go
+++ b/hasura/requests.go
@@ -41,9 +41,9 @@ type Configuration struct {
 }
 
 type ConnectionInfo struct {
-	UsePreparedStatements bool   `json:"use_prepared_statements"`
-	IsolationLevel        string `json:"isolation_level"`
-	DatabaseUrl           string `json:"database_url"`
+	UsePreparedStatements bool        `json:"use_prepared_statements"`
+	IsolationLevel        string      `json:"isolation_level"`
+	DatabaseUrl           interface{} `json:"database_url"`
 }
 
 // Source -

--- a/hasura/requests.go
+++ b/hasura/requests.go
@@ -59,7 +59,7 @@ type Table struct {
 	ObjectRelationships []interface{}      `json:"object_relationships"`
 	ArrayRelationships  []interface{}      `json:"array_relationships"`
 	SelectPermissions   []SelectPermission `json:"select_permissions"`
-	TableConfiguration  TableConfiguration `json:"configuration"`
+	Configuration       TableConfiguration `json:"configuration"`
 	Schema              TableSchema        `json:"table"`
 }
 

--- a/hasura/requests.go
+++ b/hasura/requests.go
@@ -2,12 +2,12 @@ package hasura
 
 import "github.com/pkg/errors"
 
-type request struct {
+type Request struct {
 	Type string      `json:"type"`
 	Args interface{} `json:"args"`
 }
 
-type VersionedRequest struct {
+type versionedRequest struct {
 	Type    string      `json:"type"`
 	Version int         `json:"int"`
 	Args    interface{} `json:"args"`

--- a/hasura/requests.go
+++ b/hasura/requests.go
@@ -26,6 +26,7 @@ type Metadata struct {
 	Version          int               `json:"version"`
 	Sources          []Source          `json:"sources"`
 	QueryCollections []QueryCollection `json:"query_collections,omitempty"`
+	RestEndpoints    []interface{}     `json:"rest_endpoints"`
 }
 
 func newMetadata(version int, sources []Source) *Metadata {
@@ -58,6 +59,7 @@ type Table struct {
 	ObjectRelationships []interface{}      `json:"object_relationships"`
 	ArrayRelationships  []interface{}      `json:"array_relationships"`
 	SelectPermissions   []SelectPermission `json:"select_permissions"`
+	TableConfiguration  TableConfiguration `json:"configuration"`
 	Schema              TableSchema        `json:"table"`
 }
 
@@ -71,6 +73,13 @@ func newMetadataTable(name, schema string) Table {
 			Schema: schema,
 		},
 	}
+}
+
+// TableConfiguration -
+type TableConfiguration struct {
+	Comment           *string           `json:"comment"`
+	CustomRootFields  map[string]string `json:"custom_root_fields"`
+	CustomColumnNames map[string]string `json:"custom_column_names"`
 }
 
 // TableSchema -

--- a/hasura/requests.go
+++ b/hasura/requests.go
@@ -7,6 +7,12 @@ type request struct {
 	Args interface{} `json:"args"`
 }
 
+type VersionedRequest struct {
+	Type    string      `json:"type"`
+	Version int         `json:"int"`
+	Args    interface{} `json:"args"`
+}
+
 // Permission -
 type Permission struct {
 	Columns   Columns     `json:"columns"`
@@ -18,15 +24,33 @@ type Permission struct {
 // Metadata -
 type Metadata struct {
 	Version          int               `json:"version"`
-	Tables           []Table           `json:"tables"`
+	Sources          []Source          `json:"sources"`
 	QueryCollections []QueryCollection `json:"query_collections,omitempty"`
 }
 
-func newMetadata(version int, tables []Table) *Metadata {
+func newMetadata(version int, sources []Source) *Metadata {
 	return &Metadata{
 		Version: version,
-		Tables:  tables,
+		Sources: sources,
 	}
+}
+
+type Configuration struct {
+	ConnectionInfo ConnectionInfo `json:"connection_info"`
+}
+
+type ConnectionInfo struct {
+	UsePreparedStatements bool   `json:"use_prepared_statements"`
+	IsolationLevel        string `json:"isolation_level"`
+	DatabaseUrl           string `json:"database_url"`
+}
+
+// Source -
+type Source struct {
+	Name          string        `json:"name"`
+	Kind          string        `json:"kind"`
+	Tables        []Table       `json:"tables"`
+	Configuration Configuration `json:"configuration"`
 }
 
 // Table -

--- a/hasura/responses.go
+++ b/hasura/responses.go
@@ -3,8 +3,3 @@ package hasura
 type replaceMetadataResponse struct {
 	Message string `json:"message"`
 }
-
-// ExportMetadataResponse -
-type ExportMetadataResponse struct {
-	Tables []Table `json:"tables"`
-}


### PR DESCRIPTION
Heya,

alongside the PR I made to dipdup, to allow multiple souces in a hasura instance, here's my PR for fixing/improving the hasura metadata configuration.

It includes:
- using the metadata API instad of the deprecated query API
- A source (for specifying the schema/database) and a add_source (to control if the source should be added via `pg_add_source`) config entry.
- more hasura metadata structs/definitions

Probably, there's quite a lot more to improve, but this will do for my use case (hopefully).

Please note that you'll also need this commit from https://github.com/tz1and/metadata/commit/f1af98a396161aa287b3bb0281be2be8118d9a79

Thanks!