### PR TITLE
errors.go

### DIFF
--- a/tools/tezerrors/errors.go
+++ b/tools/tezerrors/errors.go
@@ -79,7 +79,7 @@ var errorsDescrs = `{
     },
     "WrongReconstructMode": {
         "title": "Wrong reconstruct mode",
-        "descr": "Reconstruction of contexts while importing is comptible with full mode snapshots only"
+        "descr": "Reconstruction of contexts while importing is compatible with full mode snapshots only"
     },
     "WrongSnapshotExport": {
         "title": "Wrong snapshot export",


### PR DESCRIPTION
# Fix Typo in `errors.go`

## Description
This pull request addresses a typo in the `errors.go` file within the `errorsDescrs` JSON structure. The word "comptible" was corrected to "compatible" for clarity and accuracy.

### Changes Made:
- Corrected the spelling of "comptible" to "compatible" in the description field of the "WrongReconstructMode" error.

## Checklist
- [x] Verified that the change only affects the comment string and does not alter functionality.
- [x] Ensured the file maintains its consistency with the project's standards.

---

Please let me know if additional updates are needed. Thanks!
