### PR TITLE
fix /typo tzkt.go

### DIFF
--- a/tzkt/events/tzkt.go
+++ b/tzkt/events/tzkt.go
@@ -90,7 +90,7 @@ func (tzkt *TzKT) SubscribeToBlocks() error {
 
 // SubscribeToOperations - subscribe to operations channel.
 // Sends operations of specified types or related to specified accounts, included into the blockchain.
-// Filters by `address` and list of `types` is appliable.
+// Filters by `address` and list of `types` is applicable.
 func (tzkt *TzKT) SubscribeToOperations(address string, types ...string) error {
 	args := make(map[string]interface{})
 	if len(types) > 0 {


### PR DESCRIPTION
## Pull Request Title: Fix Typo in `tzkt.go`

### Description:
This pull request corrects a typo in the comment for the `SubscribeToOperations` function in the `tzkt.go` file. The word "appliable" was corrected to "applicable."

### Changes Made:
- Fixed the typo in the comment:
  - **Original:** `Filters by 'address' and list of 'types' is appliable.`
  - **Corrected:** `Filters by 'address' and list of 'types' is applicable.`

### Reason for the Change:
- The correction improves the readability and professionalism of the codebase documentation, ensuring clear and correct communication for developers referencing the function.

### Testing:
- This change only affects a comment and does not impact the code functionality. No additional testing is required.

### Additional Notes:
- This is a minor, non-breaking change.
- Thank you for reviewing this update! Please let me know if further modifications are needed.

---

Let me know if you’d like additional changes to the template or more detail!
