### PR TITLE
Typo fix hasura_integration_helpers.go

### DIFF
--- a/hasura/hasura_integration_helpers.go
+++ b/hasura/hasura_integration_helpers.go
@@ -27,7 +27,7 @@ func TestExpectedMetadataWithActual(
 ) {
 	var cfg config.Config
 	if err := config.Parse(configPath, &cfg); err != nil {
-		t.Fatalf("Error with reading configuratoin file: %s", err)
+		t.Fatalf("Error with reading configuration file: %s", err)
 	}
 
 	api := New(cfg.Hasura.URL, cfg.Hasura.Secret)


### PR DESCRIPTION
Corrected "Saftey" to "Safety" under the State Modifications section.